### PR TITLE
Suppress illegal access error

### DIFF
--- a/src/main/java/org/junit/extensions/cpsuite/ClasspathClassesFinder.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClasspathClassesFinder.java
@@ -99,6 +99,8 @@ public class ClasspathClassesFinder implements ClassesFinder {
 				// ignore not instantiable classes
 			} catch (UnsatisfiedLinkError ule) {
 				// ignore not instantiable classes
+			} catch (IllegalAccessError iae) {
+				// ignore not instantiable classes
 			}
 		}
 	}


### PR DESCRIPTION
I have a class which fails to construct due to an illegal access error. I've added another catch clause to suppress the issue.

```
java.lang.IllegalAccessError: tried to access class javax.xml.stream.FactoryFinder from class javax.xml.stream.FactoryFinder$ClassLoaderFinder
        at java.lang.Class.getDeclaringClass0(Native Method)
        at java.lang.Class.getDeclaringClass(Class.java:1235)
        at java.lang.Class.getEnclosingClass(Class.java:1277)
        at java.lang.Class.getSimpleBinaryName(Class.java:1443)
        at java.lang.Class.getSimpleName(Class.java:1309)
        at java.lang.Class.isAnonymousClass(Class.java:1411)
        at org.junit.extensions.cpsuite.ClasspathClassesFinder.gatherClasses(ClasspathClassesFinder.java:88)
        at org.junit.extensions.cpsuite.ClasspathClassesFinder.gatherClassesInRoot(ClasspathClassesFinder.java:67)
```
