### PR TITLE
Do not initialize loaded classes to avoid exceptions in static code blocks and field initialization expressions

### DIFF
--- a/src/main/java/org/junit/extensions/cpsuite/ClasspathClassesFinder.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClasspathClassesFinder.java
@@ -84,7 +84,7 @@ public class ClasspathClassesFinder implements ClassesFinder {
 				continue;
 			}
 			try {
-				Class<?> clazz = Class.forName(className);
+				Class<?> clazz = Class.forName(className, false, getClass().getClassLoader());
 				if (clazz == null || clazz.isLocalClass() || clazz.isAnonymousClass()) {
 					continue;
 				}


### PR DESCRIPTION
The standard Class.forName method initializes the loaded class which may lead to exceptions. Even worse, later tries to load that class will fail with a NoClassDefFoundError that comes without further information about the original exception. Thus its better to set the initialize flag to false. This is by the way also the standard behaviour of the Java runtime when it loads a class. Static fields will then be evaluated upon first access. See http://www.javaworld.com/article/2077332/core-java/get-a-load-of-that-name.html for a good summary about the subject.
