### PR TITLE
Fix packaging in pom.xml (takari-jar -> jar)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>io.takari.junit</groupId>
   <artifactId>takari-cpsuite</artifactId>
   <version>1.2.7-SNAPSHOT</version>
-  <packaging>takari-jar</packaging>
+  <packaging>jar</packaging>
   
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
   <groupId>io.takari.junit</groupId>
   <artifactId>takari-cpsuite</artifactId>
   <version>1.2.7-SNAPSHOT</version>
-  <packaging>jar</packaging>
   
   <dependencies>
     <dependency>


### PR DESCRIPTION
Due to invalid packaging, we have trouble resolving this jar from maven central.  More specifically, dependency resolution will try to fetch `takari-cpsuite-1.2.7.takari-jar` (which doesn't exist) instead of `takari-cpsuite-1.2.7.jar` (which does exist).