### PR TITLE
Fix off by one error in JavaStyleClassnameMatcher

### DIFF
--- a/src/main/java/org/junit/extensions/cpsuite/JavaStyleClassnameMatcher.java
+++ b/src/main/java/org/junit/extensions/cpsuite/JavaStyleClassnameMatcher.java
@@ -39,7 +39,7 @@ final class JavaStyleClassnameMatcher {
 				result.add(input.substring(start, matcher.start()));
 			}
 			result.add(matcher.group());
-			start = matcher.end() + 1;
+			start = matcher.end();
 		}
 		if (start < input.length()) {
 			result.add(input.substring(start));

--- a/src/test/java/org/junit/extensions/cpsuite/JavaStyleClassnameMatcherTest.java
+++ b/src/test/java/org/junit/extensions/cpsuite/JavaStyleClassnameMatcherTest.java
@@ -12,6 +12,7 @@ public final class JavaStyleClassnameMatcherTest {
 		assertTrue(matcher.matches("com.example.FooTest"));
 		assertFalse(matcher.matches("com.example.Foo"));
 		assertFalse(matcher.matches("com.example.foo.FooTest"));
+		assertFalse(matcher.matches("com.example.FooXest"));
 	}
 
 	@Test
@@ -21,6 +22,7 @@ public final class JavaStyleClassnameMatcherTest {
 		assertTrue(matcher.matches("com.example.FooTest"));
 		assertFalse(matcher.matches("com.example.Foo"));
 		assertTrue(matcher.matches("com.example.foo.FooTest"));
+		assertFalse(matcher.matches("com.example.foo.FooXest"));
 	}
 
 }


### PR DESCRIPTION
As mentioned in #4, there is an off-by-one error. This PR fixes that (and adds test code to prove that)