### PR TITLE
Feature to handle duplicated test classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ Negation expressions are preceded by a "!". In the previous example all tests th
 
 You can have as many positive and negative filters as you like. The positve filters still work disjunctively whereas the negated filters will subtract all matching tests after the maximum set of tests to run has been determined. Having only negated filters starts with the full set of tests.
 
+#### Duplicated Classes
+
+In some occasional cases, there may be multiple same / duplicated test classes in your classpath, which will cause some unexpected and vulnerable behavior to your test suites (e.g. using [build-helper-maven-plugin](https://www.mojohaus.org/build-helper-maven-plugin/add-test-source-mojo.html) to compile).
+
+You can use the following annotation to prune duplicated cases in your suite: only one of the same classes is kept (the first one being scanned with the same full classname):
+
+```java
+import org.junit.extensions.cpsuite.ClasspathSuite.*;
+...
+@ExcludeDuplicated(true)
+public class MySuite...
+```
+
 #### Abstract Test Classes
 
 [ClasspathSuite](http://johanneslink.net/projects/cpsuite.jsp) solves another problem (bug?) in the JUnit 4 integration of Eclipse 3.2: test classes derived from an abstract test class which do not have test methods of their own are being ignored by Eclipse's test runner. When using `RunWith(ClasspathSuite.class)` you will catch those test classes as well.

--- a/src/main/java/org/junit/extensions/cpsuite/ClassesFinderFactory.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClassesFinderFactory.java
@@ -7,5 +7,5 @@ package org.junit.extensions.cpsuite;
 
 public interface ClassesFinderFactory {
 	ClassesFinder create(boolean searchInJars, String[] filterPatterns, String[] classpathFilterPatterns, SuiteType[] suiteTypes,
-                         Class<?>[] baseTypes, Class<?>[] excludedBaseTypes, String classpathProperty);
+                         Class<?>[] baseTypes, Class<?>[] excludedBaseTypes, String classpathProperty, boolean excludeDuplicated);
 }

--- a/src/main/java/org/junit/extensions/cpsuite/ClasspathFinderFactory.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClasspathFinderFactory.java
@@ -8,9 +8,9 @@ package org.junit.extensions.cpsuite;
 public class ClasspathFinderFactory implements ClassesFinderFactory
 {
 	public ClassesFinder create(boolean searchInJars, String[] filterPatterns, String[] classpathFilterPatterns, SuiteType[] suiteTypes, Class<?>[] baseTypes,
-			Class<?>[] excludedBaseTypes, String classpathProperty) {
+			Class<?>[] excludedBaseTypes, String classpathProperty, boolean excludeDuplicated) {
 		ClassTester tester = new ClasspathSuiteTester(searchInJars, filterPatterns, classpathFilterPatterns, suiteTypes, baseTypes, excludedBaseTypes);
-		return new ClasspathClassesFinder(tester, classpathProperty);
+		return new ClasspathClassesFinder(tester, classpathProperty, excludeDuplicated);
 	}
 
 }

--- a/src/main/java/org/junit/extensions/cpsuite/ClasspathSuite.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClasspathSuite.java
@@ -24,6 +24,7 @@ import java.util.List;
 public class ClasspathSuite extends Suite {
 
 	private static final boolean DEFAULT_INCLUDE_JARS = false;
+	private static final boolean DEFAULT_EXCLUDE_DUP = false;
 	private static final SuiteType[] DEFAULT_SUITE_TYPES = new SuiteType[] { SuiteType.TEST_CLASSES };
 	private static final Class<?>[] DEFAULT_BASE_TYPES = new Class<?>[] { Object.class };
 	private static final Class<?>[] DEFAULT_EXCLUDED_BASES_TYPES = new Class<?>[0];
@@ -66,6 +67,19 @@ public class ClasspathSuite extends Suite {
 	@Target(ElementType.TYPE)
 	public @interface IncludeJars {
 		public boolean value();
+	}
+
+	/**
+	 * The <code>ExcludeDuplicated</code> annotation specifies if duplicated
+	 * classes should be excluded or not (true means only one class is kept,
+	 * other ones with duplicated class names are pruned from results).
+	 * If the annotation is missing or set to false, duplicated classes are
+	 * not being checked.
+	 */
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	public @interface ExcludeDuplicated {
+		boolean value();
 	}
 
 	/**
@@ -141,7 +155,8 @@ public class ClasspathSuite extends Suite {
 
 	private static ClassesFinder createFinder(Class<?> suiteClass, ClassesFinderFactory finderFactory) {
 		return finderFactory.create(getSearchInJars(suiteClass), getClassnameFilters(suiteClass), getClasspathFilters(suiteClass),
-                getSuiteTypes(suiteClass), getBaseTypes(suiteClass), getExcludedBaseTypes(suiteClass), getClasspathProperty(suiteClass));
+                getSuiteTypes(suiteClass), getBaseTypes(suiteClass), getExcludedBaseTypes(suiteClass), getClasspathProperty(suiteClass),
+				getExcludeDuplicated(suiteClass));
 	}
 
 	private static Class<?>[] getSortedTestclasses(ClassesFinder finder) {
@@ -180,6 +195,14 @@ public class ClasspathSuite extends Suite {
 			return DEFAULT_INCLUDE_JARS;
 		}
 		return includeJarsAnnotation.value();
+	}
+
+	private static boolean getExcludeDuplicated(Class<?> suiteClass) {
+		ExcludeDuplicated excludeDuplicatedAnnotation = suiteClass.getAnnotation(ExcludeDuplicated.class);
+		if (excludeDuplicatedAnnotation == null) {
+			return DEFAULT_EXCLUDE_DUP;
+		}
+		return excludeDuplicatedAnnotation.value();
 	}
 
 	private static SuiteType[] getSuiteTypes(Class<?> suiteClass) {


### PR DESCRIPTION
Implement annotation to avoid including duplicated classes in one test suite.

In occasional cases there may be multiple same test classes in the classpath (e.g. using the following plugin to build project, same classes found both in `target/test-classes/` and `target/classes/`):

```xml
<plugin>
    <groupId>org.codehaus.mojo</groupId>
    <artifactId>build-helper-maven-plugin</artifactId>
    <version>3.2.0</version>
    <executions>
        <execution>
            <id>add-source</id>
            <phase>generate-sources</phase>
            <goals>
                <goal>add-source</goal>
            </goals>
            <configuration>
                <sources>
                    <source>src/test/java</source>
                </sources>
            </configuration>
        </execution>
    </executions>
</plugin>
```

