### PR TITLE
Add classpath matchers

### DIFF
--- a/src/main/java/org/junit/extensions/cpsuite/AcceptAllTester.java
+++ b/src/main/java/org/junit/extensions/cpsuite/AcceptAllTester.java
@@ -5,13 +5,20 @@
  */
 package org.junit.extensions.cpsuite;
 
-public class AcceptAllTester implements ClassTester {
+public class AcceptAllTester implements ClassTester
+{
 
 	public boolean acceptClassName(String className) {
 		return true;
 	}
 
-	public boolean acceptInnerClass() {
+    @Override
+    public boolean acceptClassRoot(final String classRoot)
+    {
+        return true;
+    }
+
+    public boolean acceptInnerClass() {
 		return true;
 	}
 

--- a/src/main/java/org/junit/extensions/cpsuite/ClassTester.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClassTester.java
@@ -10,6 +10,8 @@ public interface ClassTester {
 
 	boolean acceptClassName(String className);
 
+	boolean acceptClassRoot(String classRoot);
+
 	boolean acceptInnerClass();
 
 	boolean searchInJars();

--- a/src/main/java/org/junit/extensions/cpsuite/ClassesFinderFactory.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClassesFinderFactory.java
@@ -6,6 +6,6 @@
 package org.junit.extensions.cpsuite;
 
 public interface ClassesFinderFactory {
-	ClassesFinder create(boolean searchInJars, String[] filterPatterns, SuiteType[] suiteTypes, Class<?>[] baseTypes,
-			Class<?>[] excludedBaseTypes, String classpathProperty);
+	ClassesFinder create(boolean searchInJars, String[] filterPatterns, String[] classpathFilterPatterns, SuiteType[] suiteTypes,
+                         Class<?>[] baseTypes, Class<?>[] excludedBaseTypes, String classpathProperty);
 }

--- a/src/main/java/org/junit/extensions/cpsuite/ClasspathClassesFinder.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClasspathClassesFinder.java
@@ -5,8 +5,11 @@
  */
 package org.junit.extensions.cpsuite;
 
-import java.io.*;
-import java.util.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Utility class to find classes within the class path, both inside and outside
@@ -15,7 +18,8 @@ import java.util.*;
  * 
  * It's originally evolved out of ClassPathTestCollector in JUnit 3.8.1
  */
-public class ClasspathClassesFinder implements ClassesFinder {
+public class ClasspathClassesFinder implements ClassesFinder
+{
 
 	private static final int CLASS_SUFFIX_LENGTH = ".class".length();
 	private static final String FALLBACK_CLASSPATH_PROPERTY = "java.class.path";
@@ -54,16 +58,19 @@ public class ClasspathClassesFinder implements ClassesFinder {
 
 	private void gatherClassesInRoot(File classRoot, List<Class<?>> classes) {
 		Iterable<String> relativeFilenames = new NullIterator<String>();
-		if (tester.searchInJars() && isJarFile(classRoot)) {
-			try {
-				relativeFilenames = new JarFilenameIterator(classRoot);
-			} catch (IOException e) {
-				// Don't iterate unavailable ja files
-				e.printStackTrace();
-			}
-		} else if (classRoot.isDirectory()) {
-			relativeFilenames = new RecursiveFilenameIterator(classRoot);
-		}
+        if (tester.acceptClassRoot(classRoot.getAbsolutePath())) {
+            if (tester.searchInJars() && isJarFile(classRoot)) {
+                try {
+                    relativeFilenames = new JarFilenameIterator(classRoot);
+                } catch (IOException e) {
+                    // Don't iterate unavailable ja files
+                    e.printStackTrace();
+                }
+            }
+            else if (classRoot.isDirectory()) {
+                relativeFilenames = new RecursiveFilenameIterator(classRoot);
+            }
+        }
 		gatherClasses(classes, relativeFilenames);
 	}
 

--- a/src/main/java/org/junit/extensions/cpsuite/ClasspathFinderFactory.java
+++ b/src/main/java/org/junit/extensions/cpsuite/ClasspathFinderFactory.java
@@ -5,11 +5,11 @@
  */
 package org.junit.extensions.cpsuite;
 
-public class ClasspathFinderFactory implements ClassesFinderFactory {
-
-	public ClassesFinder create(boolean searchInJars, String[] filterPatterns, SuiteType[] suiteTypes, Class<?>[] baseTypes,
+public class ClasspathFinderFactory implements ClassesFinderFactory
+{
+	public ClassesFinder create(boolean searchInJars, String[] filterPatterns, String[] classpathFilterPatterns, SuiteType[] suiteTypes, Class<?>[] baseTypes,
 			Class<?>[] excludedBaseTypes, String classpathProperty) {
-		ClassTester tester = new ClasspathSuiteTester(searchInJars, filterPatterns, suiteTypes, baseTypes, excludedBaseTypes);
+		ClassTester tester = new ClasspathSuiteTester(searchInJars, filterPatterns, classpathFilterPatterns, suiteTypes, baseTypes, excludedBaseTypes);
 		return new ClasspathClassesFinder(tester, classpathProperty);
 	}
 

--- a/src/main/java/org/junit/extensions/cpsuite/JarFilenameIterator.java
+++ b/src/main/java/org/junit/extensions/cpsuite/JarFilenameIterator.java
@@ -5,9 +5,13 @@
  */
 package org.junit.extensions.cpsuite;
 
-import java.io.*;
-import java.util.*;
-import java.util.jar.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 /**
  * This class provides an iterator over all file names in a jar file.

--- a/src/main/java/org/junit/extensions/cpsuite/JavaStyleClasspathMatcher.java
+++ b/src/main/java/org/junit/extensions/cpsuite/JavaStyleClasspathMatcher.java
@@ -1,0 +1,59 @@
+package org.junit.extensions.cpsuite;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Implements the Ant/Maven style classname matching algorithm.
+ */
+final class JavaStyleClasspathMatcher
+{
+	private static final Pattern WILDCARDS = Pattern.compile("\\*{1,2}");
+
+	private final Pattern pattern;
+
+	JavaStyleClasspathMatcher(String pattern) {
+		StringBuilder rx = new StringBuilder();
+		rx.append("^");
+		for (String part : splitIncludingSeparator(pattern)) {
+			if (part.equals("**")) {
+				rx.append(".*");
+			} else if (part.equals("*")) {
+				rx.append("[^/]*");
+			} else {
+				rx.append(Pattern.quote(part));
+			}
+		}
+		rx.append("$");
+
+		this.pattern = Pattern.compile(rx.toString());
+	}
+
+	private static Collection<String> splitIncludingSeparator(String input) {
+		Collection<String> result = new ArrayList<String>();
+		Matcher matcher = WILDCARDS.matcher(input);
+		int start = 0;
+		while (matcher.find()) {
+			if (matcher.start() > start) {
+				result.add(input.substring(start, matcher.start()));
+			}
+			result.add(matcher.group());
+			start = matcher.end() + 1;
+		}
+		if (start < input.length()) {
+			result.add(input.substring(start));
+		}
+		return result;
+	}
+
+	/**
+	 * @param classname
+	 *            the fully qualified classname to check for match.
+	 * @return true if the classname matches the filter, false otherwise.
+	 */
+	boolean matches(String classname) {
+		return pattern.matcher(classname).matches();
+	}
+}

--- a/src/main/java/org/junit/extensions/cpsuite/NullIterator.java
+++ b/src/main/java/org/junit/extensions/cpsuite/NullIterator.java
@@ -5,7 +5,8 @@
  */
 package org.junit.extensions.cpsuite;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 public class NullIterator<T> implements Iterable<T>, Iterator<T> {
 

--- a/src/main/java/org/junit/extensions/cpsuite/RecursiveFilenameIterator.java
+++ b/src/main/java/org/junit/extensions/cpsuite/RecursiveFilenameIterator.java
@@ -6,7 +6,10 @@
 package org.junit.extensions.cpsuite;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * This class provides an iterator over all file names in a directory and its

--- a/src/test/java/org/junit/extensions/cpsuite/JavaStyleClasspathMatcherTest.java
+++ b/src/test/java/org/junit/extensions/cpsuite/JavaStyleClasspathMatcherTest.java
@@ -1,0 +1,26 @@
+package org.junit.extensions.cpsuite;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class JavaStyleClasspathMatcherTest {
+	@Test
+	public void testSingleWildcard() {
+		JavaStyleClasspathMatcher matcher = new JavaStyleClasspathMatcher(
+				"project/module/*Test");
+		assertTrue(matcher.matches("project/module/FooTest"));
+		assertFalse(matcher.matches("project/module/Foo"));
+		assertFalse(matcher.matches("project/module/foo/FooTest"));
+	}
+
+	@Test
+	public void testDoubleWildcard() {
+		JavaStyleClasspathMatcher matcher = new JavaStyleClasspathMatcher(
+				"project/module/**Test");
+		assertTrue(matcher.matches("project/module/FooTest"));
+		assertFalse(matcher.matches("project/module/Foo"));
+		assertTrue(matcher.matches("project/module/foo/FooTest"));
+	}
+}


### PR DESCRIPTION
I have a large project which takes over a minute to simply analyse all the classes, however I only need one of the jars to be examined.

Classpath filters are very similar to classname filters, but allow an entire element of the classpath to be included / excluded. This is a huge speed up for me.